### PR TITLE
FireFox 118 - update urlview

### DIFF
--- a/FireFox/urlview/urlview.css
+++ b/FireFox/urlview/urlview.css
@@ -39,6 +39,9 @@
   .urlbarView-row {
     padding-inline: calc(var(--uc-urlView-full-width-padding) + var(--urlbarView-item-inline-padding)) !important;
     height: 36px !important;
+    border-top: none !important;
+    border-bottom: none !important;
+    border-right: none !important;
     border-radius: 0px !important;
   }
   :root:not([lwt-toolbar-field-focus-brighttext="true"]) 

--- a/FireFox/urlview/urlview_icons.css
+++ b/FireFox/urlview/urlview_icons.css
@@ -117,7 +117,7 @@
 .urlbar-page-action,
 #urlbar-go-button,
 .search-go-button {
-  width: 22px !important; /* Changed because of --urlbar-min-height set to 32px instead of 26 px */
+  width: auto !important; /* Changed because of --urlbar-min-height set to 32px instead of 26 px */
   height: calc(var(--urlbar-min-height) - 2px - 2 * var(--urlbar-container-padding));
   padding-top: 6px !important; /* Changed because of --urlbar-min-height set to 32px instead of 26 px */
 }


### PR DESCRIPTION
- Space between urlbar results are removed
- The width of urlbar icons should not be set as a strict width, due to the new build-in translations of Firefox, which adjusts the width of a page is translated.