### PR TITLE
C: fix removing seperator above uBo div

### DIFF
--- a/FireFox/additions/menu_left.css
+++ b/FireFox/additions/menu_left.css
@@ -1,6 +1,7 @@
 /* MENU-LEFT *************************************************************************/
 menuitem.share-tab-url-item,
 menupopup#placesContext > menuitem#placesContext_open[command="placesCmd_open"][data-l10n-id="places-open"][label="Openen"],
+menuseparator#context-media-eme-separator:nth-last-of-type(2),
 menuitem[id^="ublock0_raymondhill_net"][id$="uBlock0-viewSource"],
 menu[id^="_testpilot-containers"],
 toolbaritem#panelMenu_bookmarksMenu[tooltip="bhTooltip"][role="group"][aria-labelledby="panelMenu_recentBookmarks"][context="placesContext"],


### PR DESCRIPTION
Never fixed the separator above the uBlock element in right mouse click menu. Now it is.